### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:slim
+
+WORKDIR /app
+
+# Add and install dependencies
+ADD ./requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+# Add your scripts to the container
+ADD ./add_language_tag.py add_language_tag.py
+ADD ./clear_tags.py clear_tags.py
+
+# Set the environment variable for the interval (default to 1 hour if not provided)
+ENV INTERVAL_HOURS=1
+
+# Add an entrypoint script to handle script execution
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Use the entrypoint script to start the container
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ Dependencies:
 
 ## Run
 
-1. Set the vars JELLYFIN_URL, USERNAME, PASSWORD (tested with admin user only)
-2. Run
+Replace the enviroment variable values with the correct ones for you.
 ```sh
-python add_language_tag.py
+JELLYFIN_URL=https://jellfin.example.com JELLYFIN_USER=admin JELLYFIN_PASSWORD=example python add_language_tag.py
 ```
 
 See the comments in the files for more details
@@ -20,3 +19,13 @@ See the comments in the files for more details
 Special thanks to this gist that helped https://gist.github.com/mcarlton00/f7bd7218828ed465ce0f309cebf9a247
 
 Feel free to fork or PR if you feel it could be better.
+
+## Docker
+
+To run this as a Docker Container:
+
+1. Download the repo with the "Code" Button on Github, download as ZIP file or clone with Git
+2. Make sure you have Docker installed
+3. Open a Terminal in the folder with all the downloaded files
+4. Edit docker-compose.yml
+5. `docker-compose up`

--- a/add_language_tag.py
+++ b/add_language_tag.py
@@ -34,11 +34,13 @@
 # - Some video may not have a Language define in the Audio, resulting in a language_ tag added.
 #       I kept it like that cause it may help you edit manually if you care... I dont !
 ##
+import os
+
 import requests
-JELLYFIN_URL = 'http://localhost:8096' # To be changed !
+JELLYFIN_URL = os.getenv("JELLYFIN_URL", 'http://localhost:8096') # To be changed !
 #It has to be the admin user to be sure it works
-USERNAME = 'username'
-PASSWORD = 'password'
+USERNAME = os.getenv("JELLYFIN_USERNAME", 'username')
+PASSWORD = os.getenv("JELLYFIN_PASSWORD", 'password')
 
 
 #set 0 to do all the files in the Jellyfin server

--- a/clear_tags.py
+++ b/clear_tags.py
@@ -2,12 +2,13 @@
 # This is a cleaning script, in case you customized add_language_tag.py script but made mistakes
 # It will remove the language_xxx tags for every series and every movies 
 ##
+import os
 
 import requests
-JELLYFIN_URL = 'http://localhost:8096' # To be changed !
+JELLYFIN_URL = os.getenv("JELLYFIN_URL", 'http://localhost:8096') # To be changed !
 #It has to be the admin user to be sure it works
-USERNAME = 'usrname'
-PASSWORD = 'password'
+USERNAME = os.getenv("JELLYFIN_USERNAME", 'username')
+PASSWORD = os.getenv("JELLYFIN_PASSWORD", 'password')
 
 
 #set 0 to do all the files in the Jellyfin server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+
+services:
+  language_tag_tool:
+    image: jellyfin-language-tags:latest  # Use the name and tag of your built image
+    build:
+      context: .  # Build context is the current directory
+    environment:
+      - INTERVAL_HOURS=3  # Set environment variables here
+      - JELLYFIN_URL=https://jellyfin.example.com
+      - JELLYFIN_USERNAME=admin
+      - JELLYFIN_PASSWORD=example
+    restart: unless-stopped  # Automatically restart the container if it stops
+
+  # clear_tags_runner:
+  #   image: jellyfin-language-tags:latest
+  #   command: clear-tags
+  #   environment:
+  #     - JELLYFIN_URL=https://jellyfin.example.com
+  #     - JELLYFIN_USERNAME=admin
+  #     - JELLYFIN_PASSWORD=example
+  #   restart: "no"  # Prevent automatic restart for one-off commands

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+if [ "$1" = "clear-tags" ]; then
+    # Run the clear_tags.py script once
+    echo "Running clear_tags.py..."
+    python /app/clear_tags.py
+else
+    # Default to running add_language_tag.py on a schedule
+    INTERVAL_SECONDS=$((INTERVAL_HOURS * 3600))
+    echo "Running add_language_tag.py every $INTERVAL_HOURS hours."
+    while true; do
+        echo "Running add_language_tag.py at $(date)..."
+        python /app/add_language_tag.py
+        echo "Waiting for $INTERVAL_SECONDS seconds..."
+        sleep "$INTERVAL_SECONDS"
+    done
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Many people like to setup their Jellyfin Instances as Docker Containers, me included, and therefor it would be really nice to be able to add this "fix" to a limitation of Jellyfin directly in a Docker Compose file next to Jellyfin itself. 

This PR adds a Dockerfile and everything needed for it to work, so that the Repo can be built into a Docker Container and used. Either built locally by the user, or maybe even automatically in the Repo and published for easy download. That would be a seperate PR.